### PR TITLE
Preserve shape of reversed arcs

### DIFF
--- a/chalk/model.py
+++ b/chalk/model.py
@@ -50,7 +50,7 @@ def show_envelope(
 
     new = self + outer
     if phantom:
-        new.with_envelope(self)
+        new = new.with_envelope(self)
     return new
 
 

--- a/chalk/shapes/arc.py
+++ b/chalk/shapes/arc.py
@@ -190,6 +190,11 @@ class ArcSegment(LocatedArcSegment, TrailLike):
         else:
             return segment.to_trail()
 
+    def reverse(self) -> ArcSegment:
+        angle = self.angle + self.dangle
+        dangle = - self.dangle
+        return ArcSegment(angle, dangle).apply_transform(self.t)
+
 
 def arc_seg(q: V2, height: float) -> Trail:
     return ArcSegment.arc_between_trail(q, height)

--- a/chalk/shapes/segment.py
+++ b/chalk/shapes/segment.py
@@ -80,6 +80,9 @@ class Segment(LocatedSegment, TrailLike):
     def apply_transform(self, t: tx.Affine) -> Segment:  # type: ignore
         return Segment(tx.apply_affine(tx.remove_translation(t), self.offset))
 
+    def reverse(self) -> Segment:
+        return self.scale(-1)
+
 
 def seg(offset: V2) -> Trail:
     return Segment(offset).to_trail()

--- a/chalk/trail.py
+++ b/chalk/trail.py
@@ -105,7 +105,7 @@ class Trail(Transformable, TrailLike):
 
     def reverse(self) -> Trail:
         return Trail(
-            [seg.scale(-1) for seg in reversed(self.segments)],
+            [seg.reverse() for seg in reversed(self.segments)],
             self.closed,
         )
 

--- a/tests/test_reverse_trail.py
+++ b/tests/test_reverse_trail.py
@@ -1,0 +1,83 @@
+from hypothesis import given
+from hypothesis.strategies import (
+    DrawFn,
+    composite,
+    integers,
+    one_of,
+    sampled_from,
+)
+
+import chalk
+
+from chalk import (
+    V2,
+    Trail,
+    unit_x,
+)
+from chalk.shapes.segment import seg
+from chalk.shapes.arc import arc_seg_angle
+
+
+@composite
+def vectors(draw: DrawFn) -> V2:
+    x = draw(integers(-2, 2))
+    y = draw(integers(-2, 2))
+    return V2(x, y)
+
+
+@composite
+def transforms(draw: DrawFn) -> chalk.transform.Affine:
+    v2 = draw(vectors())
+    return draw(
+        sampled_from(
+            [
+                chalk.transform.Affine.scale(unit_x),
+                chalk.transform.Affine.scale(v2),
+                chalk.transform.Affine.translation(v2),
+                chalk.transform.Affine.rotation(v2.angle),
+            ]
+        )
+    )
+
+
+@composite
+def segment(draw: DrawFn) -> Trail:
+    dx = draw(integers())
+    dy = draw(integers())
+    return seg(V2(dx, dy))
+
+
+@composite
+def arc(draw: DrawFn) -> Trail:
+    angle = draw(integers(-360, 360))
+    dangle = draw(integers(0, 360))
+    return arc_seg_angle(angle, dangle)
+
+
+small_nat = integers(min_value=1, max_value=10)
+
+
+@composite
+def trails(draw: DrawFn) -> Trail:
+    parts = (
+        draw(one_of(segment(), arc())).apply_transform(draw(transforms()))
+        for _ in range(draw(small_nat))
+    )
+    return sum(parts, Trail.empty())
+
+
+@given(trails())
+def test_involution(t: Trail) -> None:
+    "Reverse should be an involution."
+    assert t.reverse().reverse() == t
+
+
+@given(trails(), trails())
+def test_order(t1: Trail, t2: Trail) -> None:
+    assert (t1 + t2).reverse() == t2.reverse() + t1.reverse()
+
+
+# Other possible tests?
+# - End point of reversed trail should correspond to start point of original
+#   trail (and vicevers);
+# - The shape of the trail is preserved.


### PR DESCRIPTION
This PR attempts to address #108. I've added some tests, but they don't really safeguard against the original problem (altering the trail's shape).