### PR TITLE
Several typo fixes

### DIFF
--- a/chalk/backend/cairo.py
+++ b/chalk/backend/cairo.py
@@ -45,7 +45,7 @@ def tx_to_cairo(affine: Affine) -> Any:
 
 
 class ToList(DiagramVisitor[List["Primitive"]]):
-    """Compiles a `Diagram` to a list of `Primitive`s. The transfomation `t`
+    """Compiles a `Diagram` to a list of `Primitive`s. The transformation `t`
     is accumulated upwards, from the tree's leaves.
     """
 

--- a/chalk/core.py
+++ b/chalk/core.py
@@ -66,7 +66,7 @@ class BaseDiagram(
         return Compose(envelope, self, other if other is not None else Empty())
 
     def named(self, name: Name) -> Diagram:
-        """Add a name (or a sequnce of names) to a diagram."""
+        """Add a name (or a sequence of names) to a diagram."""
         return ApplyName(name, self)
 
     # Combinators

--- a/chalk/shapes/__init__.py
+++ b/chalk/shapes/__init__.py
@@ -30,7 +30,7 @@ def vrule(length: float) -> Diagram:
 #     Args:
 #        sides (int): Number of sides.
 #        radius (float): Internal radius.
-#        rotation: (int): Rotation in degress
+#        rotation: (int): Rotation in degrees
 
 #     Returns:
 #        Diagram
@@ -113,7 +113,7 @@ def arc_between(
     at a distance of abs(height) away from the straight line from point1 to
     point2. A positive value of height results in an arc to the left of the
     line from point1 to point2; a negative value yields one to the right.
-    The implementaion is based on the the function arcBetween from Haskell's
+    The implementation is based on the the function arcBetween from Haskell's
     diagrams:
     https://hackage.haskell.org/package/diagrams-lib-1.4.5.1/docs/src/Diagrams.TwoD.Arc.html#arcBetween
     """

--- a/docs/api/transformations.py
+++ b/docs/api/transformations.py
@@ -9,7 +9,7 @@ def help(f):
 # -
 
 
-# Any Diagram (or other object in Chalk) can be transformed by affine transfomation.
+# Any Diagram (or other object in Chalk) can be transformed by affine transformation.
 # These produce a new diagram in the standard manner.
 
 # ### scale

--- a/examples/bigben.py
+++ b/examples/bigben.py
@@ -28,7 +28,7 @@ grey = Color("#444444")
 
 
 # To begin, we will introduce some of the concepts of the Chalk library
-# by mimicking the shape of the roman numberal I, V, and X.
+# by mimicking the shape of the roman numeral I, V, and X.
 
 # ![](part0.png)
 
@@ -153,7 +153,7 @@ part0.show_origin()
 
 # ![](part1.png)
 
-# This inner patten is a bit more complex. We are going to need more than just
+# This inner pattern is a bit more complex. We are going to need more than just
 # simple shapes to draw it.
 
 # To start, let us make a function for rotational symmetry.

--- a/examples/logo.py
+++ b/examples/logo.py
@@ -24,7 +24,7 @@ def mkCoords(n):
 
 def floret(r):
     n = math.floor(1.8 * math.sqrt(r)) % 5
-    # Hippie color palatte.
+    # Hippie color palette.
     colors = [Color(h) for h in ["#18b0dc",
                                  "#056753",
                                  "#b564ac",


### PR DESCRIPTION
Fixed some typos found by running [`codespell`](https://github.com/codespell-project/codespell) on the repository:

```
codespell . --skip="*.js,*.css,*.pdf" -L "te,flor,buss" 
```
